### PR TITLE
gmoccapy: fix type error

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -722,7 +722,7 @@ class gmoccapy(object):
                 size=_DEFAULT_BB_SIZE,
                 image_name=f"img_ref_{elem}"
             )
-            btn.set_property("tooltip-text", _("Press to home {0} {1}").format(name_prefix_sg, elem.upper()))
+            btn.set_property("tooltip-text", _("Press to home {0} {1}").format(name_prefix_sg, elem))
             btn.connect("clicked", self._on_btn_home_clicked)
 
             self.widgets.hbtb_ref.pack_start(btn,True,True,0)


### PR DESCRIPTION
elem is of type int and therefore has no method called upper